### PR TITLE
Add return values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ build:
 test: 
 	PYTHONPATH=python/ python3 -m pytest --log-cli-level=10 tests/python
 	tests/shell/test_cli.sh
+	tests/shell/test_returns.sh
 
 install:
 	pip install .

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -1,2 +1,47 @@
 # Licomp Comand Line Interface
 
+Licomp itself does not have any data to make a command line relevant. However, licomp has functionality that Licomp resources (implementing the [Licomp interface](https://github.com/hesa/licomp/blob/main/docs/python-api.md)). Licomp provides a generic command line interface, used by the Licomp resources, described below.
+
+The whole purpose of licomp is to determine comptibility between an outbound and an inbound license. The command to check this is `verify`.
+
+# Commands
+
+## verify
+
+Verify license compatibility between for a package or an outbound license expression against inbound license expression.
+
+### Return values
+
+`0` - compatible, i.e. inbound license can be used with outbound license
+`2` - incompatible, i.e. inbound license can not be used with outbound license
+`3` - depends, i.e. whether inbound license can be used with outbound license needs to be determined by a lawyer
+`4` - unknown, i.e. wheter inbound license can not be used with outbound license is unknown
+`5` - unsupported, i.e. one (or both) of the licenses are not supported
+`10` - internal, an internal error occured
+
+## supported-licenses
+
+List supported licenses.
+
+### Return values
+
+`0` - for success
+`10` - internal, an internal error occured
+
+## supported-usecases
+
+List supported usecases.
+
+### Return values
+
+`0` - for success
+`10` - internal, an internal error occured
+
+## supported-provisionings
+
+List supported provisionings.
+
+### Return values
+
+`0` - for success
+`10` - internal, an internal error occured

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -15,9 +15,9 @@ Verify license compatibility between for a package or an outbound license expres
 `0` - compatible, i.e. inbound license can be used with outbound license
 `2` - incompatible, i.e. inbound license can not be used with outbound license
 `3` - depends, i.e. whether inbound license can be used with outbound license needs to be determined by a lawyer
-`4` - unknown, i.e. wheter inbound license can not be used with outbound license is unknown
+`4` - unknown, i.e. whether inbound license can not be used with outbound license is unknown
 `5` - unsupported, i.e. one (or both) of the licenses are not supported
-`10` - internal, an internal error occured
+`10` - internal, an internal error occurred
 
 ## supported-licenses
 

--- a/licomp/return_codes.py
+++ b/licomp/return_codes.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2021 Henrik Sandklef
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from enum import Enum
+
+from licomp.interface import CompatibilityStatus
+
+class ReturnCodes(Enum):
+    LICOMP_OK = 0
+    LICOMP_INCONSISTENCY = 1
+    LICOMP_INCOMPATIBLE = 2
+    LICOMP_DEPENDS = 3
+    LICOMP_UNKNOWN = 4
+    LICOMP_UNSUPPORTED_LICENSE = 5
+    LICOMP_UNSUPPORTED_USECASE = 6
+    LICOMP_UNSUPPORTED_PROVISIONING = 7
+    LICOMP_UNSUPPORTED_MODIFICATION = 8
+    # ... 19 saved for future
+
+    LICOMP_MISSING_ARGUMENTS = 20
+    LICOMP_INTERNAL_ERROR = 21
+
+
+__comp_status_map__ = {
+    CompatibilityStatus.compat_status_to_string(CompatibilityStatus.COMPATIBLE): ReturnCodes.LICOMP_OK.value,
+    CompatibilityStatus.compat_status_to_string(CompatibilityStatus.INCOMPATIBLE): ReturnCodes.LICOMP_INCOMPATIBLE.value,
+    CompatibilityStatus.compat_status_to_string(CompatibilityStatus.DEPENDS): ReturnCodes.LICOMP_DEPENDS.value,
+    CompatibilityStatus.compat_status_to_string(CompatibilityStatus.UNKNOWN): ReturnCodes.LICOMP_UNKNOWN.value,
+    CompatibilityStatus.compat_status_to_string(CompatibilityStatus.UNSUPPORTED): ReturnCodes.LICOMP_UNSUPPORTED_LICENSE.value,
+}
+
+def compatibility_status_to_returncode(compat_status):
+    return __comp_status_map__[compat_status]
+
+def licomp_status_to_returncode(licomp_status_details):
+    if licomp_status_details['provisioning_status'] == 'failure':
+        return ReturnCodes.LICOMP_UNSUPPORTED_PROVISIONING.value
+    if licomp_status_details['usecase_status'] == 'failure':
+        return ReturnCodes.LICOMP_UNSUPPORTED_USECASE.value
+    if licomp_status_details['license_supported_status'] == 'failure':
+        return ReturnCodes.LICOMP_UNSUPPORTED_LICENSE.value
+    return ReturnCodes.LICOMP_INTERNAL_ERROR

--- a/tests/python/dummy_main.py
+++ b/tests/python/dummy_main.py
@@ -17,7 +17,7 @@ def main():
                             epilog = "Do not use",
                             default_usecase = UseCase.LIBRARY,
                             default_provisioning = Provisioning.BIN_DIST)
-    o_parser.run()
+    return o_parser.run()
     
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/tests/python/licomp_dummy.py
+++ b/tests/python/licomp_dummy.py
@@ -15,14 +15,24 @@ class DummyLicense(Licomp):
         Licomp.__init__(self)
         self.provisionings = [Provisioning.BIN_DIST]
         self.usecases = [UseCase.LIBRARY]
+        # The matrix below is made up for test purposes
+        # It may or may NOT reflect actual compatibilities
+        # DO NOT USE IT FOR ANYTHING (apart from testing licomp)
         self.licenses = {
+            "AFL-2.0": {
+                "GPL-2.0-only": CompatibilityStatus.INCOMPATIBLE,
+                "BSD-3-Clause": CompatibilityStatus.COMPATIBLE,
+                "AFL-2.0": CompatibilityStatus.COMPATIBLE,
+            },
             "BSD-3-Clause": {
                 "GPL-2.0-only": CompatibilityStatus.INCOMPATIBLE,
-                "BSD-3-Clause": CompatibilityStatus.COMPATIBLE
+                "BSD-3-Clause": CompatibilityStatus.COMPATIBLE,
+                "AFL-2.0": CompatibilityStatus.DEPENDS,
             },
             "GPL-2.0-only": {
                 "BSD-3-Clause": CompatibilityStatus.COMPATIBLE,
                 "GPL-2.0-only": CompatibilityStatus.COMPATIBLE,
+                "AFL-2.0": CompatibilityStatus.UNKNOWN,
             }
         }
 

--- a/tests/python/test_licomp.py
+++ b/tests/python/test_licomp.py
@@ -13,7 +13,7 @@ from licomp.interface import Modification
 dl = DummyLicense()
 
 def test_supported():
-    assert len(dl.supported_licenses()) == 2
+    assert len(dl.supported_licenses()) == 3
     
 def test_provisionings():
     assert len(dl.supported_provisionings()) == 1

--- a/tests/shell/test_cli.sh
+++ b/tests/shell/test_cli.sh
@@ -26,7 +26,7 @@ run_comp_test()
     EXP=$1
     shift
     RESP=$(dummy_cli $* | jq -r .compatibility_status)
-    echo -n "$*: "
+    printf "%-75s" "$*: "
     check_resp $RESP $EXP
     echo "OK"
 }
@@ -36,7 +36,7 @@ run_list_test()
     EXP=$1
     shift
     RESP=$(dummy_cli $* | jq -r .[] | wc -l)
-    echo -n "$*: "
+    printf "%-75s" "$*: "
     check_resp $RESP $EXP
     echo "OK"
 }
@@ -50,6 +50,6 @@ run_comp_test "null" "verify -il GPL-2.0-only -ol DO_NOT_EXIST"
 run_comp_test "null" "verify -il DO_NOT_EXIST -ol BSD-3-Clause"
 run_comp_test "null" "verify -il DO_NOT_EXIST -ol DO_NOT_EXIST"
 
-run_list_test 2 supported-licenses
+run_list_test 3 supported-licenses
 run_list_test 1 supported-provisionings
 run_list_test 1 supported-usecases

--- a/tests/shell/test_returns.sh
+++ b/tests/shell/test_returns.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2021 Henrik Sandklef
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+dummy_cli()
+{
+    PYTHONPATH=. python3 tests/python/dummy_main.py $*
+}
+
+check_ret()
+{
+    ACTUAL=$1
+    EXPECTED=$2
+
+    if [ $ACTUAL != $EXPECTED ]
+    then
+        echo "\"$ACTUAL\" != \"$EXPECTED\" :(" 
+        exit 1
+    fi
+}
+
+run_comp_test()
+{
+    EXP=$1
+    shift
+    dummy_cli $* > /dev/null 2>&1
+    RET=$?
+    printf "%-75s" "$*: "
+    check_ret $RET $EXP
+    echo "OK"
+}
+
+test_verify()
+{
+    # Success and compatible
+    run_comp_test 0 "verify -il BSD-3-Clause -ol GPL-2.0-only"
+
+    # Success and incompatible
+    run_comp_test 2 "verify -il GPL-2.0-only -ol BSD-3-Clause"
+
+    # Success and depends
+    run_comp_test 3 "verify -il AFL-2.0 -ol BSD-3-Clause"
+
+    # Success and unknown
+    run_comp_test 4 "verify -il AFL-2.0 -ol GPL-2.0-only"
+
+    # Failure, since unsupported
+    run_comp_test 5 "verify -il GPL-2.0-only -ol Unsupported"
+
+    # Failure, since usecase unsupported
+    run_comp_test 6 "--usecase snippet verify -il GPL-2.0-only -ol BSD-3-Clause"
+    run_comp_test 6 "--usecase blabla  verify -il GPL-2.0-only -ol BSD-3-Clause"
+
+    # Failure, since provisioning case unsupported
+    run_comp_test 7 "--provisioning provide-webui verify -il GPL-2.0-only -ol BSD-3-Clause"
+    run_comp_test 7 "--provisioning blabla        verify -il GPL-2.0-only -ol BSD-3-Clause"
+
+    # add modification test once modification is implemented
+
+    # check missing arguments
+    run_comp_test 20 "verify"
+    run_comp_test 20 "verify -il GPL-2.0-only"
+    run_comp_test 20 "verify -ol GPL-2.0-only"
+}
+
+test_verify


### PR DESCRIPTION
Adding return values (exit code) to indicate the status of the command. Most importantly for `verify`:

- `0` - compatible, i.e. inbound license can be used with outbound license
- `2` - incompatible, i.e. inbound license can not be used with outbound license
- `3` - depends, i.e. whether inbound license can be used with outbound license needs to be determined by a lawyer
- `4` - unknown, i.e. whether inbound license can not be used with outbound license is unknown
- `5` - unsupported, i.e. one (or both) of the licenses are not supported
- `10` - internal, an internal error occurred

Note: `1` is reserved for the classes implementing the API.


As discussed here: https://github.com/CycloneDX/cyclonedx-node-yarn/issues/242